### PR TITLE
Adds `customer_id_sum_of_customer_id` custom metric

### DIFF
--- a/dbt/models/schema.yml
+++ b/dbt/models/schema.yml
@@ -10,6 +10,23 @@ models:
         tests:
           - unique
           - not_null
+        meta:
+          metrics:
+            customer_id_sum_of_customer_id:
+              label: Sum of Customer id
+              description: >-
+                Sum of Customer id on the table Customers with filters
+                customers.customer_id
+              type: sum
+              filters:
+                - customer_id: "> 50"
+                - customer_id:
+                    - "1"
+                    - "2"
+                    - "3"
+                    - "4"
+                    - "5"
+                - first_name: A%
       - name: first_name
         description: Customer's first name. PII.
         meta:


### PR DESCRIPTION
Created by Lightdash, this pull request adds `customer_id_sum_of_customer_id` custom metric to the dbt model.

Triggered by user David Attenborough (demo@lightdash.com)
            