### PR TITLE
Adds `customer_id_count_of_customer_id` custom metric

### DIFF
--- a/dbt/models/schema.yml
+++ b/dbt/models/schema.yml
@@ -10,6 +10,12 @@ models:
         tests:
           - unique
           - not_null
+        meta:
+          metrics:
+            customer_id_count_of_customer_id:
+              label: Count of Customer id
+              description: "Count of Customer id on the table Customers "
+              type: count
       - name: first_name
         description: Customer's first name. PII.
         meta:


### PR DESCRIPTION
Created by Lightdash, this pull request adds `customer_id_count_of_customer_id` custom metric to the dbt model.

Triggered by user David Attenborough (demo@lightdash.com)
            