### PR TITLE
Adds `order_id_min_of_order_id` custom metric

### DIFF
--- a/dbt/models/schema.yml
+++ b/dbt/models/schema.yml
@@ -91,6 +91,10 @@ models:
               description: "Sum of Order id on the table Orders "
               type: sum
               filters: []
+            order_id_min_of_order_id:
+              label: Min of Order id
+              description: "Min of Order id on the table Orders "
+              type: min
       - name: is_completed
         description: Boolean indicating if status is completed
         meta:


### PR DESCRIPTION
Created by Lightdash, this pull request adds `order_id_min_of_order_id` custom metric to the dbt model.

Triggered by user David Attenborough (demo@lightdash.com)
            