### PR TITLE
Adds `order_id_max_of_order_id` custom metric

### DIFF
--- a/dbt/models/schema.yml
+++ b/dbt/models/schema.yml
@@ -103,6 +103,11 @@ models:
               type: min
               format: "#,##0.000%"
               filters: []
+            order_id_max_of_order_id:
+              label: Max of Order id
+              description: "Max of Order id on the table Orders "
+              type: max
+              filters: []
       - name: is_completed
         description: Boolean indicating if status is completed
         meta:


### PR DESCRIPTION
Created by Lightdash, this pull request adds `order_id_max_of_order_id` custom metric to the dbt model.

Triggered by user David Attenborough (demo@lightdash.com)
            