### PR TITLE
Adds `order_id_median_of_order_id` custom metric

### DIFF
--- a/dbt/models/schema.yml
+++ b/dbt/models/schema.yml
@@ -219,6 +219,13 @@ models:
               description: count of all payments
       - name: order_id
         description: Foreign key to the orders table
+        meta:
+          metrics:
+            order_id_median_of_order_id:
+              label: Median of Order id
+              description: "Median of Order id on the table Payments "
+              type: median
+              filters: []
       - name: payment_method
         description: Method of payment used, for example credit card
       - name: amount


### PR DESCRIPTION
Created by Lightdash, this pull request adds `order_id_median_of_order_id` custom metric to the dbt model.

Triggered by user David Attenborough (demo@lightdash.com)

> ⚠️ **Note: Do not change the `label` or `id` of your metrics in this pull request.** Your custom metric(s) _will not be replaced_ with YAML metrics if you change the `label` or `id` of the metrics in this pull request. Lightdash requires the IDs and labels to match 1:1 in order to replace custom metrics with YAML metrics.