### PR TITLE
Adds `status_count_distinct_of_status` custom metric

### DIFF
--- a/dbt/models/schema.yml
+++ b/dbt/models/schema.yml
@@ -152,6 +152,12 @@ models:
               label: Is status completed
               type: boolean
               sql: ${orders.status} = 'completed'
+          metrics:
+            status_count_distinct_of_status:
+              label: Count distinct of Status
+              description: "Count distinct of Status on the table Orders "
+              type: count_distinct
+              filters: []
       - name: amount
         description: Total amount (USD) of the order
         tests:


### PR DESCRIPTION
Created by Lightdash, this pull request adds `status_count_distinct_of_status` custom metric to the dbt model.
Triggered by user David Attenborough (demo@lightdash.com)

> ⚠️ **Note: Do not change the `label` or `id` of your custom metrics in this pull request.** Your custom metrics _will not be replaced_ with YAML custom metrics if you change the `label` or `id` of the custom metrics in this pull request. Lightdash requires the IDs and labels to match 1:1 in order to replace custom custom metrics with YAML custom metrics.