### PR TITLE
Adds `order_id_max_of_order_id2` custom metric

### DIFF
--- a/dbt/models/schema.yml
+++ b/dbt/models/schema.yml
@@ -108,6 +108,14 @@ models:
               description: "Max of Order id on the table Orders "
               type: max
               filters: []
+        config:
+          meta:
+            metrics:
+              order_id_max_of_order_id2:
+                label: Max of Order id2
+                description: "Max of Order id on the table Orders "
+                type: max
+                filters: []
       - name: is_completed
         description: Boolean indicating if status is completed
         meta:


### PR DESCRIPTION
Created by Lightdash, this pull request adds `order_id_max_of_order_id2` custom metric to the dbt model.
Triggered by user David Attenborough (demo@lightdash.com)

> ⚠️ **Note: Do not change the `label` or `id` of your custom metrics in this pull request.** Your custom metrics _will not be replaced_ with YAML custom metrics if you change the `label` or `id` of the custom metrics in this pull request. Lightdash requires the IDs and labels to match 1:1 in order to replace custom custom metrics with YAML custom metrics.